### PR TITLE
chore: 🔧 Update Docker image and CLI version

### DIFF
--- a/backend/packages/apps/api-server/src/app/app.module.ts
+++ b/backend/packages/apps/api-server/src/app/app.module.ts
@@ -12,7 +12,6 @@ import { TunnelModule } from "@saito/tunnel";
 import { TaskSyncModule } from '@saito/task-sync';
 import { OpenAIController } from "./controllers/openai.controller";
 import { ModelOpenaiModule } from '@saito/openai';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 @Module({
   imports: [
     forwardRef(() => OllamaModule), 
@@ -20,8 +19,7 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
     DeviceStatusModule, 
     forwardRef(() => TunnelModule), 
     TaskSyncModule,
-    ModelOpenaiModule,
-    EventEmitterModule.forRoot()
+    ModelOpenaiModule
   ],
   controllers: [IndexController, ModelController, MinerController, DeviceStatusController, OpenAIController],
   providers: [

--- a/cli/bin/index.js
+++ b/cli/bin/index.js
@@ -725,21 +725,10 @@ const registerDevice = async (options) => {
   }
 };
 
-// Download docker-compose.yml file with caching
+// Download docker-compose.yml file
 const downloadComposeFile = async () => {
   const composeUrl = CONFIG.urls.compose;
   const composeFile = 'docker-compose.yml';
-  const cacheFile = path.join(CONFIG.paths.cache, 'docker-compose.yml');
-  
-  logInfo(`Checking for cached ${composeFile}...`);
-  
-  // Check if file exists in cache
-  if (fs.existsSync(cacheFile)) {
-    logInfo(`Found cached ${composeFile}, copying to current directory...`);
-    fs.copyFileSync(cacheFile, composeFile);
-    logSuccess(`${composeFile} copied from cache successfully`);
-    return true;
-  }
   
   logInfo(`Downloading ${composeFile}...`);
   
@@ -753,11 +742,10 @@ const downloadComposeFile = async () => {
     
     const content = await response.text();
     
-    // Save to both current directory and cache
+    // Save to current directory
     fs.writeFileSync(composeFile, content);
-    fs.writeFileSync(cacheFile, content);
     
-    logSuccess(`${composeFile} downloaded and cached successfully`);
+    logSuccess(`${composeFile} downloaded successfully`);
     return true;
   } catch (error) {
     logError(`Failed to download ${composeFile}: ${error.message}`);

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sight-ai-miner-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sight-ai-miner-cli",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sight-ai-miner-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Sight AI Miner CLI - A tool for running and managing the Sight AI Miner",
   "main": "bin/index.js",
   "bin": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   sight-miner-backend:
     platform: linux/amd64
-    image: ghcr.io/sight-ai/sight-miner-backend:0.0.17-SNAPSHOT
+    image: ghcr.io/sight-ai/sight-miner-backend:0.0.18-SNAPSHOT
     ports:
       - "8716:8716"
     networks:
@@ -25,7 +25,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
     ports:
-      - "5432:5432"
+      - "5334:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
- Bumped the Docker image version for the sight-miner-backend service from 0.0.17-SNAPSHOT to 0.0.18-SNAPSHOT.
- Changed PostgreSQL port mapping from 5432 to 5334 in the docker-compose configuration.
- Updated CLI package version from 1.0.3 to 1.0.4 in package.json and package-lock.json.
- Simplified the download logic in index.js by removing caching functionality for the docker-compose.yml file.